### PR TITLE
Added unique constraint to username and actor

### DIFF
--- a/server/vagabond/models/Actor.py
+++ b/server/vagabond/models/Actor.py
@@ -7,7 +7,7 @@ from Crypto.PublicKey import RSA
 
 class Actor(APObject):
     id = db.Column(db.Integer, db.ForeignKey('ap_object.id'), primary_key=True)
-    username = db.Column(db.String(32), nullable=False)
+    username = db.Column(db.String(32), unique = True ,nullable=False)
     public_key = db.Column(db.Text(16639))
     private_key = db.Column(db.Text(16639))
 

--- a/server/vagabond/models/User.py
+++ b/server/vagabond/models/User.py
@@ -4,7 +4,7 @@ from bcrypt import hashpw, gensalt
 
 class User(db.Model):
     id = db.Column(db.Integer, nullable=False, primary_key=True)
-    username = db.Column(db.String(32), nullable=False)
+    username = db.Column(db.String(32), unique = True ,nullable=False)
     password_hash = db.Column(db.String(255), nullable=False)
 
     primary_actor_id = db.Column(db.Integer, db.ForeignKey('actor.id'))


### PR DESCRIPTION
The queries were already there at actor/user creation so not sure how Savannah was able to create duplicate actors/usernames. Once I added the unique field to the model it threw up the errors properly and did not add anything to the database.